### PR TITLE
Style city language selector like index

### DIFF
--- a/aalborg.html
+++ b/aalborg.html
@@ -6,13 +6,17 @@
   <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
-  <label for="lang-select" class="sr-only">Language</label>
-  <select id="lang-select" aria-label="Select language">
-    <option value="en">English</option>
-    <option value="ru">Русский</option>
-    <option value="lv">Latviešu</option>
-    <option value="et">Eesti</option>
-  </select>
+  <div class="language-switcher" aria-label="Language selector">
+      <label for="lang-select">Language</label>
+      <div class="language-switcher__select">
+          <select id="lang-select" aria-label="Select language">
+              <option value="en">English</option>
+              <option value="ru">Русский</option>
+              <option value="lv">Latviešu</option>
+              <option value="et">Eesti</option>
+          </select>
+      </div>
+  </div>
 
   <div class="container">
     <h1 id="page-title">Aalborg — Denmark</h1>

--- a/aarhus.html
+++ b/aarhus.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Aarhus</h2>

--- a/copenhagen.html
+++ b/copenhagen.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Copenhagen</h2>

--- a/daugavpils.html
+++ b/daugavpils.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Daugavpils</h2>

--- a/esbjerg.html
+++ b/esbjerg.html
@@ -99,13 +99,17 @@
         <h1 id="booking-header-title">HotelPaymentSystem</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels" style="text-align:center; color:#305b31;">Available Hotels in Esbjerg</h2>

--- a/espoo.html
+++ b/espoo.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Espoo</h2>

--- a/helsinki.html
+++ b/helsinki.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Helsinki</h2>

--- a/jelgava.html
+++ b/jelgava.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Jelgava</h2>

--- a/jurmala.html
+++ b/jurmala.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Jurmala</h2>

--- a/kaunas.html
+++ b/kaunas.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Kaunas</h2>

--- a/klaipeda.html
+++ b/klaipeda.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Klaipėda</h2>

--- a/liepaja.html
+++ b/liepaja.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Liepaja</h2>

--- a/narva.html
+++ b/narva.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Narva</h2>

--- a/odense.html
+++ b/odense.html
@@ -10,13 +10,17 @@
         <h1 id="booking-header-title">HotelPaymentSystem</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Odense</h2>

--- a/oulu.html
+++ b/oulu.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Oulu</h2>

--- a/panevėžys.html
+++ b/panevėžys.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Panevėžys</h2>

--- a/pärnu.html
+++ b/pärnu.html
@@ -6,13 +6,17 @@
   <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
-  <label for="lang-select" class="sr-only">Language</label>
-  <select id="lang-select" aria-label="Select language">
-    <option value="en">English</option>
-    <option value="ru">Русский</option>
-    <option value="lv">Latviešu</option>
-    <option value="et">Eesti</option>
-  </select>
+  <div class="language-switcher" aria-label="Language selector">
+      <label for="lang-select">Language</label>
+      <div class="language-switcher__select">
+          <select id="lang-select" aria-label="Select language">
+              <option value="en">English</option>
+              <option value="ru">Русский</option>
+              <option value="lv">Latviešu</option>
+              <option value="et">Eesti</option>
+          </select>
+      </div>
+  </div>
 
   <div class="container">
     <h1 id="page-title">Pärnu — Estonia</h1>

--- a/riga.html
+++ b/riga.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Riga</h2>

--- a/tallinn.html
+++ b/tallinn.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Tallinn</h2>

--- a/tampere.html
+++ b/tampere.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Tampere</h2>

--- a/tartu.html
+++ b/tartu.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Tartu</h2>

--- a/turku.html
+++ b/turku.html
@@ -134,13 +134,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Turku</h2>

--- a/viljandi.html
+++ b/viljandi.html
@@ -6,13 +6,17 @@
   <link rel="stylesheet" href="../../../styles.css">
 </head>
 <body>
-  <label for="lang-select" class="sr-only">Language</label>
-  <select id="lang-select" aria-label="Select language">
-    <option value="en">English</option>
-    <option value="ru">Русский</option>
-    <option value="lv">Latviešu</option>
-    <option value="et">Eesti</option>
-  </select>
+  <div class="language-switcher" aria-label="Language selector">
+      <label for="lang-select">Language</label>
+      <div class="language-switcher__select">
+          <select id="lang-select" aria-label="Select language">
+              <option value="en">English</option>
+              <option value="ru">Русский</option>
+              <option value="lv">Latviešu</option>
+              <option value="et">Eesti</option>
+          </select>
+      </div>
+  </div>
 
   <div class="container">
     <h1 id="page-title">Viljandi — Estonia</h1>

--- a/vilnius.html
+++ b/vilnius.html
@@ -129,13 +129,17 @@
         <h1 id="booking-header-title">Baltic Comfort</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
-    <label for="lang-select" class="sr-only">Language</label>
-    <select id="lang-select" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="ru">Русский</option>
-      <option value="lv">Latviešu</option>
-      <option value="et">Eesti</option>
-    </select>
+    <div class="language-switcher" aria-label="Language selector">
+        <label for="lang-select">Language</label>
+        <div class="language-switcher__select">
+            <select id="lang-select" aria-label="Select language">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="lv">Latviešu</option>
+                <option value="et">Eesti</option>
+            </select>
+        </div>
+    </div>
 
     <div class="booking-container">
         <h2 id="available-hotels">Available Hotels in Vilnius</h2>


### PR DESCRIPTION
Update language selector markup in city pages to match `index.html` for consistent styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b9851ec-b533-4bef-ad3a-2cd4329062e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b9851ec-b533-4bef-ad3a-2cd4329062e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

