### PR TITLE
Remove pay button white underline

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -319,6 +319,15 @@ header a { position: static !important; left: auto !important; right: auto !impo
   display: inline-block;
 }
 
+.confirm-button {
+  text-decoration: none;
+}
+
+.confirm-button:hover,
+.confirm-button:focus {
+  text-decoration: none;
+}
+
 /* -------------------------
    FEATURES / CARDS — THE "BOXES"
    (kept unchanged)


### PR DESCRIPTION
Remove the white underline from the Pay button.

---
<a href="https://cursor.com/background-agent?bcId=bc-69cc572e-0d5a-4432-bfa7-c93ace83df5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69cc572e-0d5a-4432-bfa7-c93ace83df5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents underline on `.confirm-button` in default, hover, and focus states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55da1617c6a1bc5d1e914c6271e98d8b68ace895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->