### PR TITLE
Enhance hotel page room and upsell options

### DIFF
--- a/assets/hotel-booking-summary.js
+++ b/assets/hotel-booking-summary.js
@@ -136,13 +136,98 @@
     }
   }
 
-  function renderSummary() {
-    const detailContainer = document.querySelector('.hotel-detail');
+  function toSafeDecimals(value, fallback) {
+    const numeric = typeof value === 'number' ? value : parseInt(value, 10);
+    if (!Number.isFinite(numeric)) {
+      return Number.isFinite(fallback) ? Math.max(0, Math.min(8, fallback)) : 2;
+    }
+    return Math.max(0, Math.min(8, numeric));
+  }
+
+  function getSelectedRoom(detailContainer, priceEl) {
+    if (!detailContainer) {
+      return null;
+    }
+
+    const selectedInput = detailContainer.querySelector('input[name="roomOption"]:checked');
+    if (!selectedInput) {
+      return null;
+    }
+
+    const nightlyRate = parseFloat(selectedInput.dataset.nightlyRate);
+    if (!Number.isFinite(nightlyRate) || nightlyRate <= 0) {
+      return null;
+    }
+
+    const fallbackCurrency = priceEl && priceEl.dataset ? priceEl.dataset.rateCurrency : null;
+    const currency = selectedInput.dataset.currency || fallbackCurrency || 'ETH';
+    const fallbackDecimals = priceEl && priceEl.dataset ? priceEl.dataset.rateDecimals : null;
+    const decimals = toSafeDecimals(selectedInput.dataset.decimals, toSafeDecimals(fallbackDecimals, 2));
+    const label = selectedInput.dataset.label || selectedInput.getAttribute('aria-label') || selectedInput.value || 'Selected room';
+
+    return {
+      id: selectedInput.value || label,
+      label,
+      rate: nightlyRate,
+      currency,
+      decimals
+    };
+  }
+
+  function getSelectedAddOns(detailContainer, expectedCurrency, expectedDecimals) {
+    if (!detailContainer) {
+      return [];
+    }
+
+    return Array.from(detailContainer.querySelectorAll('input[name="addonOption"]:checked'))
+      .map(function(input) {
+        const price = parseFloat(input.dataset.price);
+        if (!Number.isFinite(price) || price <= 0) {
+          return null;
+        }
+
+        const billingRaw = (input.dataset.billing || '').toLowerCase();
+        const billing = billingRaw === 'per-night' ? 'per-night' : 'per-stay';
+        const currency = input.dataset.currency || expectedCurrency || 'ETH';
+        const decimals = toSafeDecimals(input.dataset.decimals, toSafeDecimals(expectedDecimals, 2));
+        const label = input.dataset.label || input.getAttribute('aria-label') || input.value || 'Add-on';
+
+        return {
+          id: input.value || label,
+          label,
+          price,
+          billing,
+          currency,
+          decimals
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function applyRoomRate(priceEl, roomSelection) {
+    if (!priceEl || !roomSelection) {
+      return;
+    }
+
+    priceEl.dataset.rateValue = String(roomSelection.rate);
+    priceEl.dataset.rateCurrency = roomSelection.currency;
+    priceEl.dataset.rateDecimals = String(roomSelection.decimals);
+    priceEl.textContent = formatAmount(roomSelection.rate, roomSelection.decimals) + ' ' + roomSelection.currency + ' / night';
+  }
+
+  function renderSummary(detailContainer) {
+    if (!detailContainer) {
+      detailContainer = document.querySelector('.hotel-detail');
+    }
     if (!detailContainer) {
       return;
     }
 
     const priceEl = detailContainer.querySelector('.price');
+    const roomSelection = getSelectedRoom(detailContainer, priceEl);
+    if (priceEl && roomSelection) {
+      applyRoomRate(priceEl, roomSelection);
+    }
     const rate = getNightlyRate(priceEl);
 
     let summaryEl = detailContainer.querySelector('.booking-summary');
@@ -189,7 +274,72 @@
       summaryEl.appendChild(nightsEl);
     }
 
-    const totalAmount = rate.value * nights;
+    if (roomSelection) {
+      const roomEl = document.createElement('p');
+      roomEl.className = 'booking-summary__room';
+      roomEl.textContent = 'Room: ' + roomSelection.label + ' – ' + formatAmount(rate.value, rate.decimals) + ' ' + rate.currency + ' / night';
+      summaryEl.appendChild(roomEl);
+    }
+
+    const addOnSelections = getSelectedAddOns(detailContainer, rate.currency, rate.decimals);
+    var perNightAddOnTotal = 0;
+    var perStayAddOnTotal = 0;
+    var displayableAddOns = [];
+
+    addOnSelections.forEach(function(addOn) {
+      if (addOn.currency !== rate.currency) {
+        console.warn('Skipping add-on due to currency mismatch:', addOn);
+        return;
+      }
+
+      displayableAddOns.push(addOn);
+      if (addOn.billing === 'per-night') {
+        perNightAddOnTotal += addOn.price;
+      } else {
+        perStayAddOnTotal += addOn.price;
+      }
+    });
+
+    if (perNightAddOnTotal > 0) {
+      const nightlyEnhancementsEl = document.createElement('p');
+      nightlyEnhancementsEl.className = 'booking-summary__addons-nightly';
+      nightlyEnhancementsEl.textContent = 'Nightly enhancements: +' + formatAmount(perNightAddOnTotal, rate.decimals) + ' ' + rate.currency + ' / night';
+      summaryEl.appendChild(nightlyEnhancementsEl);
+    }
+
+    if (perStayAddOnTotal > 0) {
+      const stayEnhancementsEl = document.createElement('p');
+      stayEnhancementsEl.className = 'booking-summary__addons-stay';
+      stayEnhancementsEl.textContent = 'Per-stay enhancements: +' + formatAmount(perStayAddOnTotal, rate.decimals) + ' ' + rate.currency + ' per stay';
+      summaryEl.appendChild(stayEnhancementsEl);
+    }
+
+    if (displayableAddOns.length) {
+      const addOnHeading = document.createElement('p');
+      addOnHeading.className = 'booking-summary__addons-heading';
+      addOnHeading.textContent = 'Selected add-ons:';
+      summaryEl.appendChild(addOnHeading);
+
+      const addOnList = document.createElement('ul');
+      addOnList.className = 'booking-summary__addons-list';
+      displayableAddOns.forEach(function(addOn) {
+        const unitLabel = addOn.billing === 'per-night' ? ' / night' : ' per stay';
+        const listItem = document.createElement('li');
+        listItem.textContent = addOn.label + ' (+' + formatAmount(addOn.price, addOn.decimals) + ' ' + addOn.currency + unitLabel + ')';
+        addOnList.appendChild(listItem);
+      });
+      summaryEl.appendChild(addOnList);
+    }
+
+    const nightlyTotal = rate.value + perNightAddOnTotal;
+    if (perNightAddOnTotal > 0) {
+      const nightlyTotalEl = document.createElement('p');
+      nightlyTotalEl.className = 'booking-summary__nightly-total';
+      nightlyTotalEl.textContent = 'Nightly total: ' + formatAmount(nightlyTotal, rate.decimals) + ' ' + rate.currency;
+      summaryEl.appendChild(nightlyTotalEl);
+    }
+
+    const totalAmount = nightlyTotal * nights + perStayAddOnTotal;
     const totalEl = document.createElement('p');
     totalEl.className = 'booking-summary__total';
     totalEl.textContent = 'Total cost: ' + formatAmount(totalAmount, rate.decimals) + ' ' + rate.currency;
@@ -201,10 +351,46 @@
     summaryEl.appendChild(reminderEl);
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', renderSummary, { once: true });
-  } else {
+  function initializeOptionControls() {
+    const detailContainer = document.querySelector('.hotel-detail');
+    if (!detailContainer) {
+      return;
+    }
+
+    const priceEl = detailContainer.querySelector('.price');
+    const initialRoom = getSelectedRoom(detailContainer, priceEl);
+    if (initialRoom && priceEl) {
+      applyRoomRate(priceEl, initialRoom);
+    }
+
+    const roomInputs = detailContainer.querySelectorAll('input[name="roomOption"]');
+    roomInputs.forEach(function(input) {
+      input.addEventListener('change', function() {
+        const selection = getSelectedRoom(detailContainer, priceEl);
+        if (selection && priceEl) {
+          applyRoomRate(priceEl, selection);
+        }
+        renderSummary(detailContainer);
+      });
+    });
+
+    const addonInputs = detailContainer.querySelectorAll('input[name="addonOption"]');
+    addonInputs.forEach(function(input) {
+      input.addEventListener('change', function() {
+        renderSummary(detailContainer);
+      });
+    });
+  }
+
+  function start() {
+    initializeOptionControls();
     renderSummary();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
   }
 })();
 

--- a/assets/hotel-booking-summary.js
+++ b/assets/hotel-booking-summary.js
@@ -8,6 +8,7 @@
     et: 'et-EE',
     de: 'de-DE'
   };
+  const optionsConfigCache = new WeakMap();
 
   function safeGetSessionStorage() {
     try {
@@ -144,6 +145,260 @@
     return Math.max(0, Math.min(8, numeric));
   }
 
+  function getBaseCurrency(priceEl) {
+    if (!priceEl || !priceEl.dataset) {
+      return 'ETH';
+    }
+    return priceEl.dataset.rateCurrency || priceEl.dataset.currency || 'ETH';
+  }
+
+  function getBaseDecimals(priceEl) {
+    if (!priceEl || !priceEl.dataset) {
+      return 2;
+    }
+    return toSafeDecimals(priceEl.dataset.rateDecimals || priceEl.dataset.decimals, 2);
+  }
+
+  function readOptionsConfig(detailContainer) {
+    if (!detailContainer) {
+      return null;
+    }
+
+    if (optionsConfigCache.has(detailContainer)) {
+      return optionsConfigCache.get(detailContainer);
+    }
+
+    const scriptSelector = [
+      'script[type="application/json"][data-hotel-config]',
+      'script[type="application/json"][data-room-config]',
+      'script[type="application/json"].hotel-room-config'
+    ].join(', ');
+
+    const scriptEl = detailContainer.querySelector(scriptSelector);
+    if (!scriptEl) {
+      optionsConfigCache.set(detailContainer, null);
+      return null;
+    }
+
+    try {
+      const raw = (scriptEl.textContent || '').trim();
+      if (!raw) {
+        optionsConfigCache.set(detailContainer, null);
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      optionsConfigCache.set(detailContainer, parsed);
+      return parsed;
+    } catch (error) {
+      console.warn('Unable to parse hotel options config:', error);
+      optionsConfigCache.set(detailContainer, null);
+      return null;
+    }
+  }
+
+  function createRoomOptions(detailContainer, config, priceEl, insertionPoint) {
+    const rooms = Array.isArray(config && config.rooms)
+      ? config.rooms
+      : Array.isArray(config && config.roomOptions)
+        ? config.roomOptions
+        : [];
+
+    if (!rooms.length || detailContainer.querySelector('.room-options')) {
+      return;
+    }
+
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'room-options';
+
+    const legend = document.createElement('legend');
+    legend.textContent = config.roomLegend || config.roomsLegend || 'Choose your room type';
+    fieldset.appendChild(legend);
+
+    const baseCurrency = getBaseCurrency(priceEl);
+    const baseDecimals = getBaseDecimals(priceEl);
+    const hasValidExplicitDefault = rooms.some(function(room) {
+      if (!room) {
+        return false;
+      }
+      const rate = parseFloat(room.nightlyRate);
+      return Number.isFinite(rate) && rate > 0 && room.default;
+    });
+    let defaultAssigned = false;
+    let hasValidOption = false;
+
+    rooms.forEach(function(room, index) {
+      if (!room) {
+        return;
+      }
+
+      const nightlyRate = parseFloat(room.nightlyRate);
+      if (!Number.isFinite(nightlyRate) || nightlyRate <= 0) {
+        return;
+      }
+
+      const currency = room.currency || baseCurrency;
+      const decimals = toSafeDecimals(room.decimals, baseDecimals);
+      const labelText = room.label || 'Room option';
+
+      const labelEl = document.createElement('label');
+      labelEl.className = 'room-option';
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'roomOption';
+      input.value = room.id || 'room-' + index;
+      input.dataset.label = labelText;
+      input.dataset.nightlyRate = String(nightlyRate);
+      input.dataset.currency = currency;
+      input.dataset.decimals = String(decimals);
+      input.setAttribute('aria-label', labelText);
+
+      if (!defaultAssigned) {
+        if (room.default) {
+          input.checked = true;
+          defaultAssigned = true;
+        } else if (!hasValidExplicitDefault) {
+          input.checked = true;
+          defaultAssigned = true;
+        }
+      }
+
+      const detailsDiv = document.createElement('div');
+      detailsDiv.className = 'room-option__details';
+
+      const titleDiv = document.createElement('div');
+      titleDiv.className = 'room-option__title';
+      titleDiv.textContent = labelText;
+      detailsDiv.appendChild(titleDiv);
+
+      const rateDiv = document.createElement('div');
+      rateDiv.className = 'room-option__rate';
+      rateDiv.textContent = formatAmount(nightlyRate, decimals) + ' ' + currency + ' / night';
+      detailsDiv.appendChild(rateDiv);
+
+      if (room.description) {
+        const descP = document.createElement('p');
+        descP.className = 'room-option__description';
+        descP.textContent = room.description;
+        detailsDiv.appendChild(descP);
+      }
+
+      labelEl.appendChild(input);
+      labelEl.appendChild(detailsDiv);
+      fieldset.appendChild(labelEl);
+      hasValidOption = true;
+    });
+
+    if (hasValidOption) {
+      detailContainer.insertBefore(fieldset, insertionPoint);
+    }
+  }
+
+  function createAddOnOptions(detailContainer, config, priceEl, insertionPoint) {
+    const addOns = Array.isArray(config && config.addons)
+      ? config.addons
+      : Array.isArray(config && config.addOns)
+        ? config.addOns
+        : [];
+
+    if (!addOns.length || detailContainer.querySelector('.addon-options')) {
+      return;
+    }
+
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'addon-options';
+
+    const legend = document.createElement('legend');
+    legend.textContent = config.addonLegend || config.addOnsLegend || 'Enhance your stay';
+    fieldset.appendChild(legend);
+
+    const baseCurrency = getBaseCurrency(priceEl);
+    const baseDecimals = getBaseDecimals(priceEl);
+    let hasValidAddOn = false;
+
+    addOns.forEach(function(addOn, index) {
+      if (!addOn) {
+        return;
+      }
+
+      const price = parseFloat(addOn.price);
+      if (!Number.isFinite(price) || price <= 0) {
+        return;
+      }
+
+      const billing = (addOn.billing || '').toLowerCase() === 'per-night' ? 'per-night' : 'per-stay';
+      const currency = addOn.currency || baseCurrency;
+      const decimals = toSafeDecimals(addOn.decimals, baseDecimals);
+      const labelText = addOn.label || 'Add-on';
+
+      const labelEl = document.createElement('label');
+      labelEl.className = 'addon-option';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.name = 'addonOption';
+      input.value = addOn.id || 'addon-' + index;
+      input.dataset.label = labelText;
+      input.dataset.price = String(price);
+      input.dataset.billing = billing;
+      input.dataset.currency = currency;
+      input.dataset.decimals = String(decimals);
+      input.setAttribute('aria-label', labelText);
+      if (addOn.preselected) {
+        input.checked = true;
+      }
+
+      const detailsDiv = document.createElement('div');
+      detailsDiv.className = 'addon-option__details';
+
+      const titleDiv = document.createElement('div');
+      titleDiv.className = 'addon-option__title';
+      titleDiv.textContent = labelText;
+      detailsDiv.appendChild(titleDiv);
+
+      const rateDiv = document.createElement('div');
+      rateDiv.className = 'addon-option__rate';
+      const unitLabel = billing === 'per-night' ? ' / night' : ' per stay';
+      rateDiv.textContent = '+' + formatAmount(price, decimals) + ' ' + currency + unitLabel;
+      detailsDiv.appendChild(rateDiv);
+
+      if (addOn.description) {
+        const descP = document.createElement('p');
+        descP.className = 'addon-option__description';
+        descP.textContent = addOn.description;
+        detailsDiv.appendChild(descP);
+      }
+
+      labelEl.appendChild(input);
+      labelEl.appendChild(detailsDiv);
+      fieldset.appendChild(labelEl);
+      hasValidAddOn = true;
+    });
+
+    if (hasValidAddOn) {
+      detailContainer.insertBefore(fieldset, insertionPoint);
+    }
+  }
+
+  function ensureOptionControls(detailContainer) {
+    if (!detailContainer) {
+      return;
+    }
+
+    const priceEl = detailContainer.querySelector('.price');
+    const summaryEl = detailContainer.querySelector('.booking-summary');
+    const fallbackAnchor = detailContainer.querySelector('.confirm-button') || detailContainer.lastElementChild;
+    const insertionPoint = summaryEl || fallbackAnchor;
+    const config = readOptionsConfig(detailContainer);
+
+    if (!config || !insertionPoint) {
+      return;
+    }
+
+    createRoomOptions(detailContainer, config, priceEl, insertionPoint);
+    createAddOnOptions(detailContainer, config, priceEl, insertionPoint);
+  }
+
   function getSelectedRoom(detailContainer, priceEl) {
     if (!detailContainer) {
       return null;
@@ -222,6 +477,8 @@
     if (!detailContainer) {
       return;
     }
+
+    ensureOptionControls(detailContainer);
 
     const priceEl = detailContainer.querySelector('.price');
     const roomSelection = getSelectedRoom(detailContainer, priceEl);
@@ -356,6 +613,8 @@
     if (!detailContainer) {
       return;
     }
+
+    ensureOptionControls(detailContainer);
 
     const priceEl = detailContainer.querySelector('.price');
     const initialRoom = getSelectedRoom(detailContainer, priceEl);

--- a/grand-hotel-kempinski-riga.html
+++ b/grand-hotel-kempinski-riga.html
@@ -26,94 +26,6 @@
             font-size: 1.2rem;
             margin-bottom: 1rem;
         }
-        .room-options,
-        .addon-options {
-            margin-top: 1.75rem;
-            padding: 0;
-            border: none;
-        }
-        .room-options legend,
-        .addon-options legend {
-            font-size: 1.15rem;
-            font-weight: 600;
-            color: #2e4d25;
-            margin-bottom: 0.85rem;
-        }
-        .room-option,
-        .addon-option {
-            display: flex;
-            align-items: flex-start;
-            gap: 1rem;
-            padding: 1rem 1.15rem;
-            margin-bottom: 0.85rem;
-            border: 1px solid rgba(46, 125, 50, 0.25);
-            border-radius: 0.9rem;
-            background: #f9fdf9;
-            transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-            cursor: pointer;
-        }
-        .room-option:hover,
-        .addon-option:hover {
-            border-color: rgba(21, 109, 23, 0.55);
-            background: #f1fbf1;
-            box-shadow: 0 4px 12px rgba(21,109,23,0.08);
-        }
-        .room-option:focus-within,
-        .addon-option:focus-within {
-            outline: 3px solid rgba(21, 109, 23, 0.35);
-            outline-offset: 2px;
-        }
-        .room-option input,
-        .addon-option input {
-            margin-top: 0.3rem;
-        }
-        .room-option__details,
-        .addon-option__details {
-            flex: 1;
-        }
-        .addon-option__title {
-            font-weight: 700;
-            font-size: 1rem;
-            margin-bottom: 0.3rem;
-            color: #1f4b23;
-        }
-        .room-option__title {
-            font-weight: 700;
-            font-size: 1.05rem;
-            margin-bottom: 0.35rem;
-            color: #1f4b23;
-        }
-        .room-option__rate,
-        .addon-option__rate {
-            font-weight: 600;
-            color: #2e7d32;
-            margin-bottom: 0.45rem;
-        }
-        .room-option__description,
-        .addon-option__description {
-            color: #2e4d25;
-            margin: 0;
-            line-height: 1.5;
-        }
-        .booking-summary__room,
-        .booking-summary__addons-nightly,
-        .booking-summary__addons-stay,
-        .booking-summary__nightly-total {
-            margin: 0.45rem 0;
-        }
-        .booking-summary__addons-heading {
-            margin-top: 1rem;
-            font-weight: 600;
-            color: #1f4b23;
-        }
-        .booking-summary__addons-list {
-            margin: 0.35rem 0 0;
-            padding-left: 1.15rem;
-            color: #2e4d25;
-        }
-        .booking-summary__addons-list li {
-            margin: 0.25rem 0;
-        }
         .booking-summary {
             margin-top: 2rem;
             padding: 1.5rem;
@@ -172,103 +84,59 @@
         <img src="https://images.unsplash.com/photo-1512453979798-5ea266f8880c?fit=crop&w=600&q=80" alt="Grand Hotel Kempinski Riga">
         <h2>Grand Hotel Kempinski Riga</h2>
         <div class="price" data-rate-value="0.09" data-rate-currency="ETH" data-rate-decimals="2">0.09 ETH / night</div>
-        <p>
-          Overlooking the Latvian National Opera, Grand Hotel Kempinski Riga combines five-star elegance with a tranquil spa, signature rooftop bar, and bespoke concierge service for memorable stays in the capital.
-        </p>
-          <fieldset class="room-options" aria-labelledby="room-options-heading">
-              <legend id="room-options-heading">Choose your preferred room type</legend>
-              <label class="room-option">
-                  <input type="radio" name="roomOption" value="deluxe-room"
-                      data-label="Opera Deluxe Room"
-                      data-nightly-rate="0.09"
-                      data-currency="ETH"
-                      data-decimals="2"
-                      checked>
-                  <div class="room-option__details">
-                      <div class="room-option__title">Opera Deluxe Room</div>
-                      <div class="room-option__rate">0.09 ETH / night</div>
-                      <p class="room-option__description">
-                          Elegant 40 m² room overlooking the National Opera, marble bathroom, daily turndown service, and complimentary artisanal breakfast.
-                      </p>
-                  </div>
-              </label>
-              <label class="room-option">
-                  <input type="radio" name="roomOption" value="signature-suite"
-                      data-label="Signature Opera Suite"
-                      data-nightly-rate="0.14"
-                      data-currency="ETH"
-                      data-decimals="2">
-                  <div class="room-option__details">
-                      <div class="room-option__title">Signature Opera Suite</div>
-                      <div class="room-option__rate">0.14 ETH / night</div>
-                      <p class="room-option__description">
-                          65 m² suite with separate living room, private concierge line, evening champagne service, and in-room Peloton bike upon request.
-                      </p>
-                  </div>
-              </label>
-              <label class="room-option">
-                  <input type="radio" name="roomOption" value="royal-opera-suite"
-                      data-label="Royal Opera Suite"
-                      data-nightly-rate="0.21"
-                      data-currency="ETH"
-                      data-decimals="2">
-                  <div class="room-option__details">
-                      <div class="room-option__title">Royal Opera Suite</div>
-                      <div class="room-option__rate">0.21 ETH / night</div>
-                      <p class="room-option__description">
-                          Top-floor 100 m² suite featuring panoramic city views, private terrace, butler service, and chauffeured arrival in a vintage Riga cabriolet.
-                      </p>
-                  </div>
-              </label>
-          </fieldset>
-          <fieldset class="addon-options" aria-labelledby="addon-options-heading">
-              <legend id="addon-options-heading">Enhance your stay</legend>
-              <label class="addon-option">
-                  <input type="checkbox" name="addonOption" value="spa-access"
-                      data-label="Kempinski The Spa access"
-                      data-price="0.01"
-                      data-billing="per-night"
-                      data-currency="ETH"
-                      data-decimals="2">
-                  <div class="addon-option__details">
-                      <div class="addon-option__title">Kempinski The Spa access</div>
-                      <div class="addon-option__rate">+0.01 ETH / night</div>
-                      <p class="addon-option__description">
-                          Unlimited daily access to thermal suites, saunas, and the relaxation pool for all registered guests.
-                      </p>
-                  </div>
-              </label>
-              <label class="addon-option">
-                  <input type="checkbox" name="addonOption" value="airport-transfer"
-                      data-label="Private airport transfer"
-                      data-price="0.05"
-                      data-billing="per-stay"
-                      data-currency="ETH"
-                      data-decimals="2">
-                  <div class="addon-option__details">
-                      <div class="addon-option__title">Private airport transfer</div>
-                      <div class="addon-option__rate">+0.05 ETH once per stay</div>
-                      <p class="addon-option__description">
-                          Chauffeured Tesla Model X pick-up and drop-off with on-board refreshments and concierge check-in.
-                      </p>
-                  </div>
-              </label>
-              <label class="addon-option">
-                  <input type="checkbox" name="addonOption" value="rooftop-tasting"
-                      data-label="Rooftop tasting menu"
-                      data-price="0.03"
-                      data-billing="per-night"
-                      data-currency="ETH"
-                      data-decimals="2">
-                  <div class="addon-option__details">
-                      <div class="addon-option__title">Rooftop tasting menu</div>
-                      <div class="addon-option__rate">+0.03 ETH / night</div>
-                      <p class="addon-option__description">
-                          Five-course chef’s tasting menu with wine pairings on the Skyline Terrace each night of your stay.
-                      </p>
-                  </div>
-              </label>
-          </fieldset>
+          <p>
+            Overlooking the Latvian National Opera, Grand Hotel Kempinski Riga combines five-star elegance with a tranquil spa, signature rooftop bar, and bespoke concierge service for memorable stays in the capital.
+          </p>
+          <script type="application/json" data-hotel-config>
+          {
+            "roomLegend": "Choose your preferred room type",
+            "rooms": [
+              {
+                "id": "deluxe-room",
+                "label": "Opera Deluxe Room",
+                "nightlyRate": 0.09,
+                "description": "Elegant 40 m² room overlooking the National Opera with marble bathroom, daily turndown service, and complimentary artisanal breakfast.",
+                "default": true
+              },
+              {
+                "id": "signature-suite",
+                "label": "Signature Opera Suite",
+                "nightlyRate": 0.14,
+                "description": "65 m² suite with separate living room, private concierge line, evening champagne service, and in-room Peloton bike upon request."
+              },
+              {
+                "id": "royal-opera-suite",
+                "label": "Royal Opera Suite",
+                "nightlyRate": 0.21,
+                "description": "Top-floor 100 m² suite featuring panoramic city views, private terrace, butler service, and chauffeured arrival in a vintage Riga cabriolet."
+              }
+            ],
+            "addonLegend": "Enhance your stay",
+            "addons": [
+              {
+                "id": "spa-access",
+                "label": "Kempinski The Spa access",
+                "price": 0.01,
+                "billing": "per-night",
+                "description": "Unlimited daily access to thermal suites, saunas, and the relaxation pool for all registered guests."
+              },
+              {
+                "id": "airport-transfer",
+                "label": "Private airport transfer",
+                "price": 0.05,
+                "billing": "per-stay",
+                "description": "Chauffeured Tesla Model X pick-up and drop-off with on-board refreshments and concierge check-in."
+              },
+              {
+                "id": "rooftop-tasting",
+                "label": "Rooftop tasting menu",
+                "price": 0.03,
+                "billing": "per-night",
+                "description": "Five-course chef’s tasting menu with wine pairings on the Skyline Terrace each night of your stay."
+              }
+            ]
+          }
+          </script>
         <div class="booking-summary" aria-live="polite">
             <p class="booking-summary__notice">Loading your booking summary…</p>
         </div>

--- a/grand-hotel-kempinski-riga.html
+++ b/grand-hotel-kempinski-riga.html
@@ -26,6 +26,94 @@
             font-size: 1.2rem;
             margin-bottom: 1rem;
         }
+        .room-options,
+        .addon-options {
+            margin-top: 1.75rem;
+            padding: 0;
+            border: none;
+        }
+        .room-options legend,
+        .addon-options legend {
+            font-size: 1.15rem;
+            font-weight: 600;
+            color: #2e4d25;
+            margin-bottom: 0.85rem;
+        }
+        .room-option,
+        .addon-option {
+            display: flex;
+            align-items: flex-start;
+            gap: 1rem;
+            padding: 1rem 1.15rem;
+            margin-bottom: 0.85rem;
+            border: 1px solid rgba(46, 125, 50, 0.25);
+            border-radius: 0.9rem;
+            background: #f9fdf9;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+            cursor: pointer;
+        }
+        .room-option:hover,
+        .addon-option:hover {
+            border-color: rgba(21, 109, 23, 0.55);
+            background: #f1fbf1;
+            box-shadow: 0 4px 12px rgba(21,109,23,0.08);
+        }
+        .room-option:focus-within,
+        .addon-option:focus-within {
+            outline: 3px solid rgba(21, 109, 23, 0.35);
+            outline-offset: 2px;
+        }
+        .room-option input,
+        .addon-option input {
+            margin-top: 0.3rem;
+        }
+        .room-option__details,
+        .addon-option__details {
+            flex: 1;
+        }
+        .addon-option__title {
+            font-weight: 700;
+            font-size: 1rem;
+            margin-bottom: 0.3rem;
+            color: #1f4b23;
+        }
+        .room-option__title {
+            font-weight: 700;
+            font-size: 1.05rem;
+            margin-bottom: 0.35rem;
+            color: #1f4b23;
+        }
+        .room-option__rate,
+        .addon-option__rate {
+            font-weight: 600;
+            color: #2e7d32;
+            margin-bottom: 0.45rem;
+        }
+        .room-option__description,
+        .addon-option__description {
+            color: #2e4d25;
+            margin: 0;
+            line-height: 1.5;
+        }
+        .booking-summary__room,
+        .booking-summary__addons-nightly,
+        .booking-summary__addons-stay,
+        .booking-summary__nightly-total {
+            margin: 0.45rem 0;
+        }
+        .booking-summary__addons-heading {
+            margin-top: 1rem;
+            font-weight: 600;
+            color: #1f4b23;
+        }
+        .booking-summary__addons-list {
+            margin: 0.35rem 0 0;
+            padding-left: 1.15rem;
+            color: #2e4d25;
+        }
+        .booking-summary__addons-list li {
+            margin: 0.25rem 0;
+        }
         .booking-summary {
             margin-top: 2rem;
             padding: 1.5rem;
@@ -85,8 +173,102 @@
         <h2>Grand Hotel Kempinski Riga</h2>
         <div class="price" data-rate-value="0.09" data-rate-currency="ETH" data-rate-decimals="2">0.09 ETH / night</div>
         <p>
-            Overlooking the Latvian National Opera, Grand Hotel Kempinski Riga combines five-star elegance with a tranquil spa, signature rooftop bar, and bespoke concierge service for memorable stays in the capital.
+          Overlooking the Latvian National Opera, Grand Hotel Kempinski Riga combines five-star elegance with a tranquil spa, signature rooftop bar, and bespoke concierge service for memorable stays in the capital.
         </p>
+          <fieldset class="room-options" aria-labelledby="room-options-heading">
+              <legend id="room-options-heading">Choose your preferred room type</legend>
+              <label class="room-option">
+                  <input type="radio" name="roomOption" value="deluxe-room"
+                      data-label="Opera Deluxe Room"
+                      data-nightly-rate="0.09"
+                      data-currency="ETH"
+                      data-decimals="2"
+                      checked>
+                  <div class="room-option__details">
+                      <div class="room-option__title">Opera Deluxe Room</div>
+                      <div class="room-option__rate">0.09 ETH / night</div>
+                      <p class="room-option__description">
+                          Elegant 40 m² room overlooking the National Opera, marble bathroom, daily turndown service, and complimentary artisanal breakfast.
+                      </p>
+                  </div>
+              </label>
+              <label class="room-option">
+                  <input type="radio" name="roomOption" value="signature-suite"
+                      data-label="Signature Opera Suite"
+                      data-nightly-rate="0.14"
+                      data-currency="ETH"
+                      data-decimals="2">
+                  <div class="room-option__details">
+                      <div class="room-option__title">Signature Opera Suite</div>
+                      <div class="room-option__rate">0.14 ETH / night</div>
+                      <p class="room-option__description">
+                          65 m² suite with separate living room, private concierge line, evening champagne service, and in-room Peloton bike upon request.
+                      </p>
+                  </div>
+              </label>
+              <label class="room-option">
+                  <input type="radio" name="roomOption" value="royal-opera-suite"
+                      data-label="Royal Opera Suite"
+                      data-nightly-rate="0.21"
+                      data-currency="ETH"
+                      data-decimals="2">
+                  <div class="room-option__details">
+                      <div class="room-option__title">Royal Opera Suite</div>
+                      <div class="room-option__rate">0.21 ETH / night</div>
+                      <p class="room-option__description">
+                          Top-floor 100 m² suite featuring panoramic city views, private terrace, butler service, and chauffeured arrival in a vintage Riga cabriolet.
+                      </p>
+                  </div>
+              </label>
+          </fieldset>
+          <fieldset class="addon-options" aria-labelledby="addon-options-heading">
+              <legend id="addon-options-heading">Enhance your stay</legend>
+              <label class="addon-option">
+                  <input type="checkbox" name="addonOption" value="spa-access"
+                      data-label="Kempinski The Spa access"
+                      data-price="0.01"
+                      data-billing="per-night"
+                      data-currency="ETH"
+                      data-decimals="2">
+                  <div class="addon-option__details">
+                      <div class="addon-option__title">Kempinski The Spa access</div>
+                      <div class="addon-option__rate">+0.01 ETH / night</div>
+                      <p class="addon-option__description">
+                          Unlimited daily access to thermal suites, saunas, and the relaxation pool for all registered guests.
+                      </p>
+                  </div>
+              </label>
+              <label class="addon-option">
+                  <input type="checkbox" name="addonOption" value="airport-transfer"
+                      data-label="Private airport transfer"
+                      data-price="0.05"
+                      data-billing="per-stay"
+                      data-currency="ETH"
+                      data-decimals="2">
+                  <div class="addon-option__details">
+                      <div class="addon-option__title">Private airport transfer</div>
+                      <div class="addon-option__rate">+0.05 ETH once per stay</div>
+                      <p class="addon-option__description">
+                          Chauffeured Tesla Model X pick-up and drop-off with on-board refreshments and concierge check-in.
+                      </p>
+                  </div>
+              </label>
+              <label class="addon-option">
+                  <input type="checkbox" name="addonOption" value="rooftop-tasting"
+                      data-label="Rooftop tasting menu"
+                      data-price="0.03"
+                      data-billing="per-night"
+                      data-currency="ETH"
+                      data-decimals="2">
+                  <div class="addon-option__details">
+                      <div class="addon-option__title">Rooftop tasting menu</div>
+                      <div class="addon-option__rate">+0.03 ETH / night</div>
+                      <p class="addon-option__description">
+                          Five-course chef’s tasting menu with wine pairings on the Skyline Terrace each night of your stay.
+                      </p>
+                  </div>
+              </label>
+          </fieldset>
         <div class="booking-summary" aria-live="polite">
             <p class="booking-summary__notice">Loading your booking summary…</p>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1216,3 +1216,103 @@ html.page-selectlocation .site-nav .nav-inner {
   }
 }
 
+/* -------------------------
+   Hotel room & add-on selectors
+   ------------------------- */
+.hotel-detail .room-options,
+.hotel-detail .addon-options {
+  margin-top: 1.75rem;
+  padding: 0;
+  border: none;
+}
+
+.hotel-detail .room-options legend,
+.hotel-detail .addon-options legend {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #2e4d25;
+  margin-bottom: 0.85rem;
+}
+
+.hotel-detail .room-option,
+.hotel-detail .addon-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.15rem;
+  margin-bottom: 0.85rem;
+  border: 1px solid rgba(46, 125, 50, 0.25);
+  border-radius: 0.9rem;
+  background: #f9fdf9;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.hotel-detail .room-option:hover,
+.hotel-detail .addon-option:hover {
+  border-color: rgba(21, 109, 23, 0.55);
+  background: #f1fbf1;
+  box-shadow: 0 4px 12px rgba(21, 109, 23, 0.08);
+}
+
+.hotel-detail .room-option:focus-within,
+.hotel-detail .addon-option:focus-within {
+  outline: 3px solid rgba(21, 109, 23, 0.35);
+  outline-offset: 2px;
+}
+
+.hotel-detail .room-option input,
+.hotel-detail .addon-option input {
+  margin-top: 0.3rem;
+}
+
+.hotel-detail .room-option__details,
+.hotel-detail .addon-option__details {
+  flex: 1;
+}
+
+.hotel-detail .room-option__title,
+.hotel-detail .addon-option__title {
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin-bottom: 0.35rem;
+  color: #1f4b23;
+}
+
+.hotel-detail .room-option__rate,
+.hotel-detail .addon-option__rate {
+  font-weight: 600;
+  color: #2e7d32;
+  margin-bottom: 0.45rem;
+}
+
+.hotel-detail .room-option__description,
+.hotel-detail .addon-option__description {
+  color: #2e4d25;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.hotel-detail .booking-summary__room,
+.hotel-detail .booking-summary__addons-nightly,
+.hotel-detail .booking-summary__addons-stay,
+.hotel-detail .booking-summary__nightly-total {
+  margin: 0.45rem 0;
+}
+
+.hotel-detail .booking-summary__addons-heading {
+  margin-top: 1rem;
+  font-weight: 600;
+  color: #1f4b23;
+}
+
+.hotel-detail .booking-summary__addons-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.15rem;
+  color: #2e4d25;
+}
+
+.hotel-detail .booking-summary__addons-list li {
+  margin: 0.25rem 0;
+}
+

--- a/wellton-riverside-riga.html
+++ b/wellton-riverside-riga.html
@@ -87,6 +87,56 @@
         <p>
             Situated between Riga Old Town and the Daugava River, Wellton Riverside offers contemporary rooms, a panoramic rooftop terrace, and a wellness area with sauna, pool, and hydro-massage.
         </p>
+          <script type="application/json" data-hotel-config>
+          {
+            "roomLegend": "Select your room category",
+            "rooms": [
+              {
+                "id": "riverside-deluxe",
+                "label": "Riverside Deluxe Room",
+                "nightlyRate": 0.06,
+                "description": "Bright 32 m² room with river views, walk-in rain shower, and complimentary Baltic breakfast buffet.",
+                "default": true
+              },
+              {
+                "id": "panorama-suite",
+                "label": "Panorama Suite",
+                "nightlyRate": 0.095,
+                "description": "Spacious corner suite featuring wraparound windows, private sauna access, and evening prosecco service."
+              },
+              {
+                "id": "club-suite",
+                "label": "Riverside Club Suite",
+                "nightlyRate": 0.13,
+                "description": "Executive-level suite with separate lounge, dedicated concierge, and exclusive club lounge refreshments."
+              }
+            ],
+            "addonLegend": "Optional enhancements",
+            "addons": [
+              {
+                "id": "thermal-spa",
+                "label": "Spa & Thermal zone access",
+                "price": 0.008,
+                "billing": "per-night",
+                "description": "Unlimited use of saunas, steam room, and hydrotherapy pool throughout your stay."
+              },
+              {
+                "id": "river-cruise",
+                "label": "Daugava evening river cruise",
+                "price": 0.04,
+                "billing": "per-stay",
+                "description": "Private two-hour sunset cruise with sommelier-selected wines and local mezze platter."
+              },
+              {
+                "id": "wine-tasting",
+                "label": "Latvian wine tasting flight",
+                "price": 0.02,
+                "billing": "per-night",
+                "description": "Sommelier-guided tasting of boutique Latvian wines served in the Sky Bar."
+              }
+            ]
+          }
+          </script>
         <div class="booking-summary" aria-live="polite">
             <p class="booking-summary__notice">Loading your booking summary…</p>
         </div>


### PR DESCRIPTION
Add configurable room tiers and upsell blocks to hotel pages, enabling dynamic pricing and booking summary updates.

The changes allow hotel chains to easily merchandise premium room inventory and additional services directly on individual property pages, with the booking summary automatically reflecting user selections for rooms and add-ons.

---
<a href="https://cursor.com/background-agent?bcId=bc-858c8277-ce14-4384-951a-c9b6bcc356f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-858c8277-ce14-4384-951a-c9b6bcc356f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

