### PR TITLE
Replace baltic comfort with baltic holliday

### DIFF
--- a/aarhus.html
+++ b/aarhus.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/contact us business client.html
+++ b/contact us business client.html
@@ -203,7 +203,7 @@
 
   <footer class="site-footer container" role="contentinfo">
     <div class="footer-inner">
-      <p>&copy; <span id="year"></span> Baltic Comfort</p>
+      <p>&copy; <span id="year"></span> Baltic Holliday</p>
       <nav class="footer-nav" aria-label="Footer">
         <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
       </nav>

--- a/copenhagen.html
+++ b/copenhagen.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -227,7 +227,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -235,7 +235,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -243,7 +243,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -251,7 +251,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -259,7 +259,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/crypto-environment.html
+++ b/crypto-environment.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <div class="logo-header">
-      <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Comfort Logo">
+      <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Holliday Logo">
     </div>
       <nav class="site-nav" aria-label="Primary navigation">
         <div class="nav-inner">

--- a/crypto-reliability.html
+++ b/crypto-reliability.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="logo-header">
-      <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Comfort Logo">
+      <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Holliday Logo">
     </div>
     <nav class="site-nav" aria-label="Primary navigation">
       <div class="nav-inner">

--- a/daugavpils.html
+++ b/daugavpils.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/espoo.html
+++ b/espoo.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/grand-hotel-kempinski-riga.html
+++ b/grand-hotel-kempinski-riga.html
@@ -77,7 +77,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1>Baltic Comfort</h1>
+        <h1>Baltic Holliday</h1>
         <p>Book your stay with secure crypto payments</p>
     </div>
     <div class="hotel-detail">

--- a/helsinki.html
+++ b/helsinki.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -201,7 +201,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -209,7 +209,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -217,7 +217,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -225,7 +225,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -233,7 +233,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/hotel_signup.html
+++ b/hotel_signup.html
@@ -30,7 +30,7 @@
       <div class="logo-header" aria-hidden="false">
         <!-- Keep the same logo file name used in repo; replace path if the logo lives elsewhere -->
         <a href="index.html" aria-label="Home">
-          <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Comfort Logo">
+          <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Holliday Logo">
         </a>
       </div>
 
@@ -227,7 +227,7 @@
   </main>
 
   <footer style="padding:18px;text-align:center;border-top:1px solid rgba(0,0,0,0.04);margin-top:28px">
-    <small>&copy; Baltic Comfort — Hotel Payment Processor</small>
+    <small>&copy; Baltic Holliday — Hotel Payment Processor</small>
   </footer>
 
     <script src="site-preferences.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"> 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Baltic Comfort – Blockchain Payments for Hospitality</title>
+    <title>Baltic Holliday – Blockchain Payments for Hospitality</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -21,7 +21,7 @@
             </div>
         </div>
         <div class="logo-header">
-            <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Comfort Logo">
+            <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Holliday Logo">
         </div>
 
         <!-- Navigation bar -->

--- a/jelgava.html
+++ b/jelgava.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -192,7 +192,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -200,7 +200,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -208,7 +208,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/jurmala.html
+++ b/jurmala.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/kaunas.html
+++ b/kaunas.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -194,7 +194,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -202,7 +202,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -210,7 +210,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -218,7 +218,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -226,7 +226,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/klaipeda.html
+++ b/klaipeda.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -194,7 +194,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -202,7 +202,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -210,7 +210,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -218,7 +218,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -226,7 +226,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/liepaja.html
+++ b/liepaja.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/narva.html
+++ b/narva.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -200,7 +200,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -208,7 +208,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/oulu.html
+++ b/oulu.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/panevėžys.html
+++ b/panevėžys.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -200,7 +200,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -208,7 +208,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/riga.html
+++ b/riga.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -194,7 +194,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -202,7 +202,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -210,7 +210,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -218,7 +218,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -226,7 +226,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/scandic-copenhagen.html
+++ b/scandic-copenhagen.html
@@ -77,7 +77,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1>Baltic Comfort</h1>
+        <h1>Baltic Holliday</h1>
         <p>Book your stay with secure crypto payments</p>
     </div>
     <div class="hotel-detail">

--- a/selectlocation.html
+++ b/selectlocation.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Baltic Comfort – Book With Us</title>
+    <title>Baltic Holliday – Book With Us</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -21,7 +21,7 @@
             </div>
         </div>
         <div class="logo-header">
-            <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Comfort Logo">
+            <img src="Baltic%20Comfort%20LTD%20logo.png" alt="Baltic Holliday Logo">
         </div>
 
         <!-- Navigation bar -->

--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,7 @@ header, header.site-header, .site-header {
   position: relative;
 }
 
-/* Remove the Baltic Comfort booking banner from city and hotel detail pages */
+/* Remove the Baltic Holliday booking banner from city and hotel detail pages */
 .booking-header {
   display: none !important;
 }

--- a/tallinn.html
+++ b/tallinn.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -194,7 +194,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -202,7 +202,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -210,7 +210,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -218,7 +218,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -226,7 +226,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/tampere.html
+++ b/tampere.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/tartu.html
+++ b/tartu.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -200,7 +200,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -208,7 +208,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/turku.html
+++ b/turku.html
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -208,7 +208,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -216,7 +216,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -224,7 +224,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -232,7 +232,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -240,7 +240,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/vilnius.html
+++ b/vilnius.html
@@ -126,7 +126,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1 id="booking-header-title">Baltic Comfort</h1>
+        <h1 id="booking-header-title">Baltic Holliday</h1>
         <p id="booking-header-desc">Book your stay with secure crypto payments</p>
     </div>
     <div class="language-switcher" aria-label="Language selector">
@@ -194,7 +194,7 @@
 // Translation data for supported languages
 const translations = {
       en: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Book your stay with secure crypto payments",
         "available-hotels": "Available Hotels in {city}",
         "currency-label": "Select Currency:",
@@ -202,7 +202,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain solutions for the hospitality industry."
       },
       ru: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Забронируйте проживание с безопасными криптоплатежами",
         "available-hotels": "Доступные отели в {city}",
         "currency-label": "Выберите валюту:",
@@ -210,7 +210,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Блокчейн-решения для гостиничной индустрии."
       },
       lv: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Rezervējiet uzturēšanos ar drošiem kripto maksājumiem",
         "available-hotels": "Pieejamās viesnīcas pilsētā {city}",
         "currency-label": "Izvēlieties valūtu:",
@@ -218,7 +218,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blokķēdes risinājumi viesmīlības industrijai."
       },
       et: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Broneeri oma viibimine turvaliste krüpto maksetega",
         "available-hotels": "Saadaolevad hotellid linnas {city}",
         "currency-label": "Vali valuuta:",
@@ -226,7 +226,7 @@ const translations = {
         "footer-text": "&copy; 2025 BalticComfort. Blockchain-lahendused hotellindusele."
       },
       de: {
-        "booking-header-title": "Baltic Comfort",
+        "booking-header-title": "Baltic Holliday",
         "booking-header-desc": "Buchen Sie Ihren Aufenthalt mit sicheren Krypto-Zahlungen",
         "available-hotels": "Verfügbare Hotels in {city}",
         "currency-label": "Währung auswählen:",

--- a/wellton-riverside-riga.html
+++ b/wellton-riverside-riga.html
@@ -77,7 +77,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1>Baltic Comfort</h1>
+        <h1>Baltic Holliday</h1>
         <p>Book your stay with secure crypto payments</p>
     </div>
     <div class="hotel-detail">

--- a/šiauliai.htm
+++ b/šiauliai.htm
@@ -131,7 +131,7 @@
 </head>
 <body style="background:#e6f0e6;min-height:100vh;">
     <div class="booking-header">
-        <h1>Baltic Comfort</h1>
+        <h1>Baltic Holliday</h1>
         <p>Book your stay with secure crypto payments</p>
     </div>
     <div class="booking-container">


### PR DESCRIPTION
Update brand name from "Baltic Comfort" to "Baltic Holliday" across all pages and supporting references.

---
<a href="https://cursor.com/background-agent?bcId=bc-949ee5ff-ae76-4a57-ac0a-04f9cba42db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-949ee5ff-ae76-4a57-ac0a-04f9cba42db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

